### PR TITLE
Add documentation for  escaping some characters

### DIFF
--- a/docs/help/in/eval.in
+++ b/docs/help/in/eval.in
@@ -11,11 +11,17 @@
 
     Evaluates the given commands and executes them; you can use internal
     variables and separate multiple commands by using the ';' character.
+    If the command contains a string with '$', '\' or ';' those characters 
+    need to be escaped:
+        '$' -> '$$'
+        '\' -> '\\' (or even '\\\\', depending on where they are used)
+        ';' -> '\;'
 
 %9Examples:%9
 
     /EVAL echo I am connected to ${S} on ${chatnet} as ${N}
     /EVAL echo My user privileges are +${usermode}; echo Let's party!
+    to print '1;2$3\4': /EVAL echo 1\;2$$3\\4       
 
 %9References:%9
 

--- a/docs/help/in/network.in
+++ b/docs/help/in/network.in
@@ -18,7 +18,8 @@
     -usermode:       Specifies the user modes to set on yourself.
     -autosendcmd:    Specifies the commands, separated by the ';' character,
                      and enclosed within two "'" characters, to perform after
-                     connecting.
+                     connecting. 
+                     (Some characters need to be escaped - see /help eval)
     -querychans:     Specifies the maximum number of channels to put in one MODE
                      or WHO command when synchronizing.
     -whois:          Specifies the maximum number of nicknames in one WHOIS


### PR DESCRIPTION
fixes #1329 
this is especially important when using `sendcmd` to send a password for autologin

The important place is `/help network sendcmd` but putting the complete text there would clutter things. So I followed what @ailin-nemui suggested and 
- put it into `/help eval` 
- with a pointer in `/help network`

by Guntbert Reiter