### PR TITLE
Improve handling of GLib log messages

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #define IRSSI_GLOBAL_CONFIG "irssi.conf" /* config file name in /etc/ */
 #define IRSSI_HOME_CONFIG "config" /* config file name in ~/.irssi/ */
 
-#define IRSSI_ABI_VERSION 42
+#define IRSSI_ABI_VERSION 43
 
 #define DEFAULT_SERVER_ADD_PORT 6667
 #define DEFAULT_SERVER_ADD_TLS_PORT 6697

--- a/src/fe-common/core/fe-common-core.c
+++ b/src/fe-common/core/fe-common-core.c
@@ -165,6 +165,7 @@ void fe_common_core_init(void)
 	settings_add_bool("lookandfeel", "use_msgs_window", FALSE);
 	g_get_charset(&str);
 	settings_add_str("lookandfeel", "term_charset", str);
+	settings_add_str("lookandfeel", "glib_log_domains", "all");
 	themes_init();
         theme_register(fecommon_core_formats);
 
@@ -254,9 +255,54 @@ void fe_common_core_deinit(void)
         signal_remove("channel destroyed", (SIGNAL_FUNC) sig_channel_destroyed);
 }
 
-void i_log_func(const char *log_domain, GLogLevelFlags log_level, const char *message)
+static gboolean glib_domain_wanted(const char *domain)
 {
-	const char *reason;
+	const char *domains;
+	char *c, *cur;
+	int len = 0;
+	int print_it = 0; /* -1 for exclude, 0 for undecided, 1 for include */
+	int incl;
+
+	/* Go through each item in glib_log_domains setting to determine whether
+	 * or not we want to print message from this domain */
+	domains = settings_get_str("glib_log_domains");
+	c = cur = (char *) domains;
+
+	do {
+		/* Advance through the string until we hit a space or the end */
+		while (*cur != '\0' && *cur != ' ') {
+			cur++;
+			len++;
+		}
+
+		/* Handle '-' prefix */
+		incl = 1;
+		if (*c == '-') {
+			incl = -1;
+			c++;
+			len--;
+		}
+
+		/* If we got a valid item, process it */
+		if (len > 0 && (!strncmp(domain, c, len) || !strncasecmp("all", c, len) ||
+		                !strncmp("*", c, len)))
+			print_it = incl;
+
+		/* Go past any spaces towards the next item */
+		while (*cur == ' ')
+			cur++;
+
+		/* Move on beyond the item we just handled */
+		c = cur;
+		len = 0;
+	} while (*c != '\0' && print_it != -1);
+
+	return (print_it == 1);
+}
+
+static void i_log_func(const char *log_domain, GLogLevelFlags log_level, const char *message)
+{
+	const char *reason, *domain;
 
 	switch (log_level) {
 	case G_LOG_LEVEL_WARNING:
@@ -265,16 +311,33 @@ void i_log_func(const char *log_domain, GLogLevelFlags log_level, const char *me
 	case G_LOG_LEVEL_CRITICAL:
                 reason = "critical";
 		break;
+	case G_LOG_LEVEL_DEBUG:
+		reason = "debug";
+		break;
+	case G_LOG_LEVEL_MESSAGE:
+		reason = "message";
+		break;
+	case G_LOG_LEVEL_INFO:
+		reason = "info";
+		break;
 	default:
 		reason = "error";
                 break;
 	}
 
+	/* If log_domain parameter is NULL, GLib means to tell us that this is
+	 * meant to be some nebulous "default" log domain name. */
+	domain = (log_domain ? log_domain : "default");
+
+	/* Only print the message if we decided to */
+	if (!glib_domain_wanted(domain))
+		return;
+
 	if (windows == NULL)
-		fprintf(stderr, "GLib %s: %s\n", reason, message);
+		fprintf(stderr, "GLib (%s) %s: %s\n", domain, reason, message);
 	else {
-		printformat(NULL, NULL, MSGLEVEL_CLIENTERROR,
-			    TXT_GLIB_ERROR, reason, message);
+		printformat(NULL, NULL, MSGLEVEL_CLIENTERROR, TXT_GLIB_ERROR, domain, reason,
+		            message);
 	}
 }
 

--- a/src/fe-common/core/module-formats.c
+++ b/src/fe-common/core/module-formats.c
@@ -288,7 +288,7 @@ FORMAT_REC fecommon_core_formats[] = {
 	{ "config_saved", "Saved configuration to file $0", 1, { 0 } },
 	{ "config_reloaded", "Reloaded configuration", 1, { 0 } },
 	{ "config_modified", "Configuration file was modified since irssi was last started - do you want to overwrite the possible changes?", 1, { 0 } },
-	{ "glib_error", "{error $0} $1", 2, { 0, 0 } },
+	{ "glib_error", "{error ($0) $1} $2", 3, { 0, 0, 0 } },
 	{ "overwrite_config", "Overwrite config (y/N)?", 0 },
 	{ "set_title", "[{hilight $0}]", 1, { 0 } },
 	{ "set_item", "$[-!32]0 %_$1", 2, { 0, 0 } },


### PR DESCRIPTION
This patch introduces setting "glib_log_domains", which is
a space-separated list of log domain names, optionally prefixed
with a '-'. The list is parsed from left to right to determine
whether or not user wants to see message from a particular log
domain. Keywords 'all' or '*' are allowed as well.
Examples: "GLib-GIO", "all -GLib-GIO", "-*"

This patch also changes the default format for displaying GLib log
messages to include the log domain.

By Andrej Kacian